### PR TITLE
Add queries for outline

### DIFF
--- a/languages/query/outline.scm
+++ b/languages/query/outline.scm
@@ -1,0 +1,8 @@
+(named_node
+  name: (_) @name) @item
+
+(anonymous_node 
+  name: (_) @name) @item
+
+(field_definition
+  name: (_) @name) @item


### PR DESCRIPTION
This adds query support for the outline, so that we can use the outline feature in zed.

A screenshot of zed's outline for the `cpp/outline.scm` file:

<img width="299" height="659" alt="image" src="https://github.com/user-attachments/assets/ea12992d-f92b-40c7-8e87-ff9ef0ff102d" />


 